### PR TITLE
Fix: Fixed the PORTS expose for Frontend and Backend

### DIFF
--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     environment:
       - POSTGRES_HOST=relational_db
       - REDIS_HOST=redis://redis:6379
+    ports:
+      - "8000:8000"
 
   frontend:
     image: idinsight/experiment_engine_frontend:latest
@@ -31,6 +33,8 @@ services:
     restart: always
     env_file:
       - .base.env
+    ports:
+      - "3000:3000"
 
   relational_db:
     image: postgres:16.4


### PR DESCRIPTION
Reviewer:
Estimate:

---

## Ticket

Fixes: JIRA_TICKET_LINK

## Description

### Goal
Ensure that both the backend and frontend services are accessible by properly exposing the required ports in the docker-compose.yml file.

### Changes
- Added missing ports configuration to the docker-compose.yml file for both backend and frontend services.
- This allows the services to be reachable from the host machine for local development and testing.
- Verified port bindings and container connectivity to ensure services are accessible via their respective ports.

### Future Tasks (optional)

## How has this been tested?
- Ran docker-compose up locally.
- Verified frontend loads correctly in the browser.
- Verified API endpoints are reachable from the frontend.
- Checked logs to confirm proper container startup with port bindings.

## To-do before merge (optional)

## Checklist

Fill with `x` for completed.

- [X] My code follows the style guidelines of this project
- [X] I have reviewed my own code to ensure good quality
- [X] I have tested the functionality of my code to ensure it works as intended
- [X] I have resolved merge conflicts
- [X] I have updated the automated tests (if applicable)
- [X] I have updated the requirements (if applicable)
- [X] I have updated the README file (if applicable)
- [X] I have updated affected documentation (if applicable)
- [X] I have added a blogpost in Latest Updates
- [X] I have updated the CI/CD scripts in `.github/workflows/`
- [X] I have updated the Terraform code
