### PR TITLE
[DOC] fix typos: 'abouth' -> 'about', 'notfications' -> 'notifications'

### DIFF
--- a/docs/getting-started/experiments/bayes_ab/setting-up.md
+++ b/docs/getting-started/experiments/bayes_ab/setting-up.md
@@ -30,4 +30,4 @@ The priors are defined through the `Mean` and `Standard Deviation` parameters of
 
 Click on the `Next` button to proceed.
 
-Once you've set up notfications and created the experiment, you can now run the experiment with your users, in the [same way as you would for MABs](../mabs/run-experiment.md).
+Once you've set up notifications and created the experiment, you can now run the experiment with your users, in the [same way as you would for MABs](../mabs/run-experiment.md).

--- a/docs/getting-started/experiments/cmabs/setting-up.md
+++ b/docs/getting-started/experiments/cmabs/setting-up.md
@@ -39,4 +39,4 @@ The priors are defined through the `Mean` and `Standard Deviation` parameters of
 
 Click on the `Next` button to proceed.
 
-Once you've set up notfications and created the experiment, you can now [run the experiment](./run-experiment.md) with your users.
+Once you've set up notifications and created the experiment, you can now [run the experiment](./run-experiment.md) with your users.

--- a/docs/getting-started/experiments/index.md
+++ b/docs/getting-started/experiments/index.md
@@ -1,6 +1,6 @@
 # Experiments
 
-Learn abouth the types of experiments we have implemented, and how to configure them.
+Learn about the types of experiments we have implemented, and how to configure them.
 
 <div class="grid cards" markdown>
 

--- a/docs/getting-started/experiments/mabs/run-experiment.md
+++ b/docs/getting-started/experiments/mabs/run-experiment.md
@@ -13,7 +13,7 @@ You can then use this ID to record the outcome of presenting the arm you drew to
 
 The `update_arm` endpoint updates the prior probability of the corresponding arm based on the observed outcome.
 
-As you observe more and more outcomes, you can track the experiment's progress using Experiment Cards and the notfications.
+As you observe more and more outcomes, you can track the experiment's progress using Experiment Cards and the notifications.
 
 ![Experiment card](./images/experiment_card.png)
 

--- a/docs/getting-started/experiments/mabs/setting-up.md
+++ b/docs/getting-started/experiments/mabs/setting-up.md
@@ -38,4 +38,4 @@ Similarly, for the Normal prior for the arms, the priors are defined through the
 
 Click on the `Next` button to proceed.
 
-Once you've set up notfications and created the experiment, you can now [run the experiment](./run-experiment.md) with your users.
+Once you've set up notifications and created the experiment, you can now [run the experiment](./run-experiment.md) with your users.


### PR DESCRIPTION
Five small typo fixes in the getting-started experiments docs:

- docs/getting-started/experiments/index.md: 'abouth' -> 'about'
- docs/getting-started/experiments/bayes_ab/setting-up.md: 'notfications' -> 'notifications'
- docs/getting-started/experiments/mabs/run-experiment.md: 'notfications' -> 'notifications'
- docs/getting-started/experiments/mabs/setting-up.md: 'notfications' -> 'notifications'
- docs/getting-started/experiments/cmabs/setting-up.md: 'notfications' -> 'notifications'

No content changes — typo fixes only.

Reviewer:
Estimate:

---

## Ticket

Fixes: JIRA_TICKET_LINK

## Description

### Goal

### Changes

### Future Tasks (optional)

## How has this been tested?

## To-do before merge (optional)

## Checklist

Fill with `x` for completed.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have updated the requirements (if applicable)
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
